### PR TITLE
fix: remove build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 ## Install dependencies
 `yarn`
-## Build
-`yarn bootstrap`
 ## Voting Events:
 These are subgraphs related to the core Oracle contracts. The code can be found in `packages/voting`
 - Kovan: https://thegraph.com/explorer/subgraph/nicholaspai/mainnet-voting-staging

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
       "type": "git",
       "url": "git+https://github.com/UMAprotocol/subgraphs.git"
     },
-    "scripts": {
-      "bootstrap": "npx lerna bootstrap"
-    },
+    "scripts": {},
     "bugs": {
       "url": "https://github.com/UMAprotocol/subgraphs/issues"
     },


### PR DESCRIPTION
The build command did the same thing as `yarn`, so it's not needed.