### PR TITLE
fix(voting): Change start block for mainnet VotingAncillary

### DIFF
--- a/packages/voting/manifest/data/mainnet.json
+++ b/packages/voting/manifest/data/mainnet.json
@@ -23,7 +23,7 @@
             "name": "VotingAncillary",
             "abi": "VotingAncillary",
             "address": "0x8b1631ab830d11531ae83725fda4d86012eccd77",
-            "startBlock": 11929550
+            "startBlock": 11876839
         }
     ]
 }

--- a/packages/voting/manifest/templates/VotingAncillary.template.yaml
+++ b/packages/voting/manifest/templates/VotingAncillary.template.yaml
@@ -18,15 +18,13 @@
       - PriceIdentifier
       - Store
     abis:
-      - name: Voting
-        file: ./abis/Voting.json
       - name: VotingAncillary
         file: ./abis/VotingAncillary.json
       - name: VotingToken
         file: ./abis/VotingToken.json
     eventHandlers:
       - event: PriceRequestAdded(indexed uint256,indexed bytes32,uint256)
-        handler: handlePriceRequestAdded
+        handler: handlePriceRequestAddedAncillary
       - event: PriceResolved(indexed uint256,indexed bytes32,uint256,int256,bytes)
         handler: handlePriceResolvedAncillary
       - event: RewardsRetrieved(indexed address,indexed uint256,indexed bytes32,uint256,bytes,uint256)

--- a/packages/voting/src/index.ts
+++ b/packages/voting/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from "./mappings/voting";
 
 export {
+  handlePriceRequestAdded as handlePriceRequestAddedAncillary,
   handleVoteRevealed as handleVoteRevealedAncillary,
   handleVoteCommitted as handleVoteCommittedAncillary,
   handlePriceResolved as handlePriceResolvedAncillary,

--- a/packages/voting/src/mappings/voting.ts
+++ b/packages/voting/src/mappings/voting.ts
@@ -50,6 +50,15 @@ export function handlePriceRequestAdded(event: PriceRequestAdded): void {
   requestRound.time = event.params.time;
   requestRound.roundId = event.params.roundId;
 
+  log.warning(
+    `New Price Request Saved: {},{},{}`, 
+    [
+      request.time.toString(),
+      request.latestRound,
+      request.identifier
+    ]
+  );
+
   requestRound.save();
   request.save();
 }
@@ -60,7 +69,7 @@ export function handlePriceRequestAdded(event: PriceRequestAdded): void {
 
 export function handlePriceResolved(event: PriceResolved): void {
   log.warning(
-    `Price Resolved params: {}{}{}`, 
+    `Price Resolved params: {},{},{}`, 
     [
       event.params.time.toString(),
       event.params.identifier.toString(),
@@ -72,6 +81,15 @@ export function handlePriceResolved(event: PriceResolved): void {
     .concat("-")
     .concat(event.params.time.toString());
   let request = getOrCreatePriceRequest(requestId);
+
+  log.warning(
+    `Fetched Price Request Entity: {},{},{}`, 
+    [
+      request.time.toString(),
+      request.latestRound,
+      request.identifier
+    ]
+  );
   let requestRound = getOrCreatePriceRequestRound(
     requestId.concat("-").concat(event.params.roundId.toString())
   );


### PR DESCRIPTION
Previous start block was after the first `PriceRequestAdded` event causing subsequent `PriceResolved` handlers to throw because the initial data hadn't been loaded in via `handlePriceRequestAdded`