### PR TITLE
feat: add global apr

### DIFF
--- a/packages/votingV2/schema.graphql
+++ b/packages/votingV2/schema.graphql
@@ -1,4 +1,4 @@
-type Globals @entity {
+type Global @entity {
   id: ID!
 
   "List of all users addresses"
@@ -13,6 +13,9 @@ type Globals @entity {
   "Annual Voting Token emission at current emission rate"
   annualVotingTokenEmission: BigDecimal!
 
+  "Earnings percentage from staking over a 12-month period, exclusive of slashing and compound interest"
+  annualPercentageReturn: BigDecimal!
+
   "Higher index to process among all users"
   maxNextIndexToProcess: BigInt!
 
@@ -22,7 +25,7 @@ type Globals @entity {
 
   countCorrectVotes: BigInt!
 
-  users: [User!] @derivedFrom(field: "globals")
+  users: [User!] @derivedFrom(field: "global")
 }
 
 type User @entity {
@@ -81,7 +84,7 @@ type User @entity {
 
   votesSlashed: [SlashedVote!]! @derivedFrom(field: "voter")
 
-  globals: Globals!
+  global: Global!
 }
 
 type Collateral @entity {

--- a/packages/votingV2/src/utils/helpers/voting.ts
+++ b/packages/votingV2/src/utils/helpers/voting.ts
@@ -1,6 +1,6 @@
 import {
   CommittedVote,
-  Globals,
+  Global,
   PriceRequest,
   PriceRequestRound,
   RevealedVote,
@@ -9,24 +9,25 @@ import {
   VoterGroup,
 } from "../../../generated/schema";
 import { BIGDECIMAL_ZERO, BIGINT_ZERO } from "../constants";
-export const GLOBALS = "globals";
+export const GLOBAL = "global";
 
-export function getOrCreateGlobals(): Globals {
-  let request = Globals.load(GLOBALS);
+export function getOrCreateGlobals(): Global {
+  let request = Global.load(GLOBAL);
 
   if (request == null) {
-    request = new Globals(GLOBALS);
+    request = new Global(GLOBAL);
     request.userAddresses = [];
     request.cumulativeStake = BIGDECIMAL_ZERO;
     request.emissionRate = BIGDECIMAL_ZERO;
     request.annualVotingTokenEmission = BIGDECIMAL_ZERO;
+    request.annualPercentageReturn = BIGDECIMAL_ZERO;
     request.maxNextIndexToProcess = BIGINT_ZERO;
     request.countCorrectVotes = BIGINT_ZERO;
     request.countWrongVotes = BIGINT_ZERO;
     request.countNoVotes = BIGINT_ZERO;
   }
 
-  return request as Globals;
+  return request as Global;
 }
 
 export function getOrCreatePriceRequest(id: String, createIfNotFound: boolean = true): PriceRequest {

--- a/packages/votingV2/src/utils/helpers/votingToken.ts
+++ b/packages/votingV2/src/utils/helpers/votingToken.ts
@@ -9,14 +9,14 @@ export function getOrCreateUser(id: Address, createIfNotFound: boolean = true): 
   let user = User.load(id.toHexString());
 
   if (user == null && createIfNotFound) {
-    let globals = getOrCreateGlobals();
+    let global = getOrCreateGlobals();
     user = new User(id.toHexString());
     user.address = id;
     user.countReveals = BIGINT_ZERO;
     user.countCorrectVotes = BIGINT_ZERO;
     user.countWrongVotes = BIGINT_ZERO;
     user.countNoVotes = BIGINT_ZERO;
-    user.globals = globals.id;
+    user.global = global.id;
     user.annualPercentageReturn = BIGDECIMAL_ZERO;
     user.annualReturn = BIGDECIMAL_ZERO;
     user.cumulativeCalculatedSlash = BIGDECIMAL_ZERO;
@@ -30,7 +30,7 @@ export function getOrCreateUser(id: Address, createIfNotFound: boolean = true): 
     user.cumulativeSlash = BIGDECIMAL_ZERO;
 
     user.save();
-    globals.save();
+    global.save();
   }
 
   return user as User;


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

Changes proposed in this PR:
- Add global `annualPercentageReturn` available in the `globals` query

```
{
    globals(where:{id:"global"}){
        annualPercentageReturn
    }
}
```

Subgraph deployed:
UI:
https://thegraph.com/hosted-service/subgraph/md0x/votingv2-version-111
API:
https://api.thegraph.com/subgraphs/name/md0x/votingv2-version-111
