### PR TITLE
feat: update votingv2 events

### DIFF
--- a/packages/votingV2/manifest/data/goerli.json
+++ b/packages/votingV2/manifest/data/goerli.json
@@ -11,8 +11,8 @@
   "VotingDataSources": [
     {
       "name": "Voting",
-      "address": "0xF71cdF8A34c56933A8871354A2570a301364e95F",
-      "startBlock": 7998822
+      "address": "0xBc3683DEf184ad64f6162024BD401e8D49d0E517",
+      "startBlock": 8265529
     }
   ],
   "StoreDataSources": [

--- a/packages/votingV2/manifest/templates/VotingV2.template.yaml
+++ b/packages/votingV2/manifest/templates/VotingV2.template.yaml
@@ -23,13 +23,13 @@
       - name: VotingToken
         file: ./abis/VotingToken.json
     eventHandlers:
-      - event: PriceRequestAdded(indexed address,indexed uint256,uint256,indexed bytes32,uint256,bytes,bool)
+      - event: RequestAdded(indexed address,indexed uint256,indexed bytes32,uint256,bytes,bool)
         handler: handlePriceRequestAdded
-      - event: VoteCommitted(indexed address,indexed address,uint256,uint256,indexed bytes32,uint256,bytes)
+      - event: VoteCommitted(indexed address,indexed address,uint256,indexed bytes32,uint256,bytes)
         handler: handleVoteCommitted
-      - event: VoteRevealed(indexed address,indexed address,uint256,uint256,indexed bytes32,uint256,bytes,int256,uint256)
+      - event: VoteRevealed(indexed address,indexed address,uint256,indexed bytes32,uint256,bytes,int256,uint256)
         handler: handleVoteRevealed
-      - event: PriceResolved(indexed uint256,indexed uint256,indexed bytes32,uint256,bytes,int256)
+      - event: RequestResolved(indexed uint256,indexed uint256,indexed bytes32,uint256,bytes,int256)
         handler: handlePriceResolved
       - event: Staked(indexed address,indexed address,uint256,uint256,uint256,uint256)
         handler: handleStaked
@@ -41,7 +41,11 @@
         handler: handleUpdatedReward
       - event: WithdrawnRewards(indexed address,indexed address,uint256)
         handler: handleWithdrawnRewards
-      - event: VoterSlashed(indexed address,int256,uint256)
+      - event: VoterSlashed(indexed address,indexed uint256,int256)
         handler: handleVoterSlashed
+      - event: RequestDeleted(indexed bytes32,indexed uint256,bytes,uint256)
+        handler: handleRequestDeleted
+      - event: RequestRolled(indexed bytes32,indexed uint256,bytes,uint256)
+        handler: handleRequestRolled
 
 

--- a/packages/votingV2/schema.graphql
+++ b/packages/votingV2/schema.graphql
@@ -117,14 +117,20 @@ type PriceRequest @entity {
   "ID is the PriceIdentifier ID + the timestamp"
   id: ID!
 
-  "The price request index"
-  requestIndex: BigInt!
+  "The price request resolved index"
+  resolvedPriceRequestIndex: BigInt
 
   "Depicts whether the request has been resolved"
   isResolved: Boolean!
 
+  "Depicts whether the request has been deleted after rolling too many rounds"
+  isDeleted: Boolean!
+
   "Price resolved for this request"
   price: BigInt
+
+  "Number of rounds that this request has been rolled"
+  rollCount: BigInt!
 
   "PriceRequestRound entity corresponding to the last round of voting"
   latestRound: PriceRequestRound

--- a/packages/votingV2/src/index.ts
+++ b/packages/votingV2/src/index.ts
@@ -8,7 +8,9 @@ export {
   handleExecutedUnstake,
   handleUpdatedReward,
   handleWithdrawnRewards,
-  handleVoterSlashed
+  handleVoterSlashed,
+  handleRequestDeleted,
+  handleRequestRolled,
 } from "./mappings/votingV2";
 
 export { handleSupportedIdentifierAdded, handleSupportedIdentifierRemoved } from "./mappings/identifierWhitelist";

--- a/packages/votingV2/src/utils/helpers/voting.ts
+++ b/packages/votingV2/src/utils/helpers/voting.ts
@@ -36,6 +36,8 @@ export function getOrCreatePriceRequest(id: String, createIfNotFound: boolean = 
   if (request == null && createIfNotFound) {
     request = new PriceRequest(id);
     request.isResolved = false;
+    request.isDeleted = false;
+    request.rollCount = BIGINT_ZERO;
   }
 
   return request as PriceRequest;


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@umaproject.org>

Changes proposed in this PR:
- Update mapper with event changes
- Add new events mappers
- Fix slashing amounts in `votesSlashed`
- priceRequests now have `rollCount` and `isDeleted` properties


Latest subgraph deployment: 
UI: https://thegraph.com/hosted-service/subgraph/md0x/votingv2-version-130
API: https://api.thegraph.com/subgraphs/name/md0x/votingv2-version-130

See new voting v2 contracts in goerli: https://github.com/UMAprotocol/protocol/pull/4368/files
