### PR TITLE
feat: update votingV2 contracts

### DIFF
--- a/packages/votingV2/manifest/data/goerli.json
+++ b/packages/votingV2/manifest/data/goerli.json
@@ -11,8 +11,8 @@
   "VotingDataSources": [
     {
       "name": "Voting",
-      "address": "0x1755DD08108095C48509F5C91e071e0cb62eb27a",
-      "startBlock": 8265523
+      "address": "0xc48F2d8491AffFc8eB21c85dEa1B4c0259c749a0",
+      "startBlock": 8507127
     }
   ],
   "StoreDataSources": [

--- a/packages/votingV2/package.json
+++ b/packages/votingV2/package.json
@@ -7,7 +7,7 @@
     "codegen": "graph codegen",
     "build": "graph build",
     "importAbi": "scripts/copy-contracts-abis.sh",
-    "prepare:goerli": "npm run importAbi && scripts/build-manifest.sh goerli && yarn codegen && yarn build",
+    "prepare:goerli": "scripts/build-manifest.sh goerli && yarn codegen && yarn build",
     "prepare:mainnet": "npm run importAbi && scripts/build-manifest.sh mainnet && yarn codegen && yarn build",
     "prepare:kovan": "npm run importAbi && scripts/build-manifest.sh kovan && yarn codegen && yarn build",
     "prepare:polygon": "npm run importAbi && scripts/build-manifest.sh polygon && yarn codegen && yarn build",

--- a/packages/votingV2/schema.graphql
+++ b/packages/votingV2/schema.graphql
@@ -209,14 +209,14 @@ type PriceRequestRound @entity {
   "Percentage of the total supply of tokens that were weighted on this vote"
   tokenVoteParticipationPercentage: BigDecimal
 
-  "gat expressed exactly as in the contract"
-  gat: BigDecimal
+  "minParticipationRequirement expressed exactly as in the contract"
+  minParticipationRequirement: BigDecimal
 
-  "The raw percentage that the gat represents of total supply . 1 = 100%"
-  gatPercentageRaw: BigDecimal
+  "minAgreementRequirement expressed as a percentage value"
+  minAgreementRequirement: BigDecimal
 
-  "gatPercentage expressed as a percentage value"
-  gatPercentage: BigDecimal
+  "SlashingLibrary address used for this round"
+  slashingLibrary: String
 
   winnerGroup: VoterGroup
 
@@ -264,7 +264,6 @@ type TransactionSlashedVotes @entity {
 }
 
 type SlashedVote @entity {
-
   id: ID!
 
   request: PriceRequest!

--- a/packages/votingV2/schema.graphql
+++ b/packages/votingV2/schema.graphql
@@ -212,7 +212,7 @@ type PriceRequestRound @entity {
   "minParticipationRequirement expressed exactly as in the contract"
   minParticipationRequirement: BigDecimal
 
-  "minAgreementRequirement expressed as a percentage value"
+  "minAgreementRequirement expressed exactly as in the contract"
   minAgreementRequirement: BigDecimal
 
   "SlashingLibrary address used for this round"

--- a/packages/votingV2/src/mappings/votingV2.ts
+++ b/packages/votingV2/src/mappings/votingV2.ts
@@ -129,7 +129,7 @@ export function handlePriceResolved(event: RequestResolved): void {
   let roundInfo = votingContract.try_rounds(event.params.roundId);
   let cumulativeStakeAtRound = roundInfo.reverted
     ? toDecimal(BigInt.fromString("0"))
-    : toDecimal(roundInfo.value.value1);
+    : toDecimal(roundInfo.value.value3);
 
   request.latestRound = requestRound.id;
   request.price = event.params.price;
@@ -145,13 +145,10 @@ export function handlePriceResolved(event: RequestResolved): void {
   requestRound.time = event.params.time;
   requestRound.roundId = event.params.roundId;
   requestRound.winnerGroup = voterGroup.id;
-  requestRound.gat = roundInfo.reverted ? requestRound.gat : toDecimal(roundInfo.value.value0);
+  requestRound.slashingLibrary = roundInfo.value.value0.toHexString();
+  requestRound.minParticipationRequirement = toDecimal(roundInfo.value.value1);
+  requestRound.minAgreementRequirement = toDecimal(roundInfo.value.value2);
 
-  requestRound.gatPercentageRaw = safeDivBigDecimal(
-    defaultBigDecimal(requestRound.gat),
-    toDecimal(getTokenContract().try_totalSupply().value)
-  );
-  requestRound.gatPercentage = defaultBigDecimal(requestRound.gatPercentageRaw).times(BIGDECIMAL_HUNDRED);
   requestRound.cumulativeStakeAtRound = cumulativeStakeAtRound;
 
   requestRound.save();


### PR DESCRIPTION
Changes proposed in this PR:
- Update the votingV2 subgraph to store the:
 - minParticipationRequirement (gat) per price request per round
 - minAgreementRequirement (spat) per price request per round
 - slashing library per price request per round