### PR TITLE
feat: check for resolvable requests every block

### DIFF
--- a/packages/votingV2/manifest/templates/VotingV2.template.yaml
+++ b/packages/votingV2/manifest/templates/VotingV2.template.yaml
@@ -47,5 +47,7 @@
         handler: handleRequestDeleted
       - event: RequestRolled(indexed bytes32,indexed uint256,bytes,uint32)
         handler: handleRequestRolled
+    blockHandlers:
+      - handler: handleBlock
 
 

--- a/packages/votingV2/schema.graphql
+++ b/packages/votingV2/schema.graphql
@@ -4,6 +4,9 @@ type Global @entity {
   "List of all users addresses"
   userAddresses: [String!]!
 
+  "List of all active price requests with at least one revealed vote"
+  activePriceRequests: [ID!]!
+
   "Cumulative stake from all users"
   cumulativeStake: BigDecimal!
 
@@ -141,6 +144,10 @@ type PriceRequest @entity {
   "PriceIdentifier for the request"
   identifier: PriceIdentifier!
 
+  "PriceIdentifier for the request hex encoded"
+  identifierRaw: String
+
+  "Ancillary data for the request"
   ancillaryData: String
 
   "Transaction where the creation of the request took place"

--- a/packages/votingV2/src/index.ts
+++ b/packages/votingV2/src/index.ts
@@ -11,6 +11,7 @@ export {
   handleVoterSlashed,
   handleRequestDeleted,
   handleRequestRolled,
+  handleBlock
 } from "./mappings/votingV2";
 
 export { handleSupportedIdentifierAdded, handleSupportedIdentifierRemoved } from "./mappings/identifierWhitelist";

--- a/packages/votingV2/src/utils/helpers/voting.ts
+++ b/packages/votingV2/src/utils/helpers/voting.ts
@@ -17,6 +17,7 @@ export function getOrCreateGlobals(): Global {
   if (request == null) {
     request = new Global(GLOBAL);
     request.userAddresses = [];
+    request.activePriceRequests = [];
     request.cumulativeStake = BIGDECIMAL_ZERO;
     request.emissionRate = BIGDECIMAL_ZERO;
     request.annualVotingTokenEmission = BIGDECIMAL_ZERO;


### PR DESCRIPTION
Changes proposed in this PR:

Motivation: We need to check for resolvable requests at every block
- Add `activePriceRequests` to store the price requests to check every block. These are price requests with at least one reveal
- Add a block handler function `handleBlock` to check for resolvable price requests and store the resolution price