### PR TITLE
feat: add optimistic governor entity

### DIFF
--- a/packages/optimistic-governor/abis/Safe.json
+++ b/packages/optimistic-governor/abis/Safe.json
@@ -1,0 +1,457 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "AddedOwner",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "approvedHash", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" }
+    ],
+    "name": "ApproveHash",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "handler", "type": "address" }],
+    "name": "ChangedFallbackHandler",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "guard", "type": "address" }],
+    "name": "ChangedGuard",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint256", "name": "threshold", "type": "uint256" }],
+    "name": "ChangedThreshold",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "module", "type": "address" }],
+    "name": "DisabledModule",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "module", "type": "address" }],
+    "name": "EnabledModule",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "bytes32", "name": "txHash", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "payment", "type": "uint256" }
+    ],
+    "name": "ExecutionFailure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "module", "type": "address" }],
+    "name": "ExecutionFromModuleFailure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "module", "type": "address" }],
+    "name": "ExecutionFromModuleSuccess",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "bytes32", "name": "txHash", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "payment", "type": "uint256" }
+    ],
+    "name": "ExecutionSuccess",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "RemovedOwner",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "module", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "indexed": false, "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" }
+    ],
+    "name": "SafeModuleTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "indexed": false, "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" },
+      { "indexed": false, "internalType": "uint256", "name": "safeTxGas", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "baseGas", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "gasPrice", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "gasToken", "type": "address" },
+      { "indexed": false, "internalType": "address payable", "name": "refundReceiver", "type": "address" },
+      { "indexed": false, "internalType": "bytes", "name": "signatures", "type": "bytes" },
+      { "indexed": false, "internalType": "bytes", "name": "additionalInfo", "type": "bytes" }
+    ],
+    "name": "SafeMultiSigTransaction",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "sender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "SafeReceived",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "initiator", "type": "address" },
+      { "indexed": false, "internalType": "address[]", "name": "owners", "type": "address[]" },
+      { "indexed": false, "internalType": "uint256", "name": "threshold", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "initializer", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "fallbackHandler", "type": "address" }
+    ],
+    "name": "SafeSetup",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "bytes32", "name": "msgHash", "type": "bytes32" }],
+    "name": "SignMsg",
+    "type": "event"
+  },
+  { "stateMutability": "nonpayable", "type": "fallback" },
+  {
+    "inputs": [],
+    "name": "VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+    ],
+    "name": "addOwnerWithThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "hashToApprove", "type": "bytes32" }],
+    "name": "approveHash",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "bytes32", "name": "", "type": "bytes32" }
+    ],
+    "name": "approvedHashes",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "_threshold", "type": "uint256" }],
+    "name": "changeThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "dataHash", "type": "bytes32" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" },
+      { "internalType": "uint256", "name": "requiredSignatures", "type": "uint256" }
+    ],
+    "name": "checkNSignatures",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "dataHash", "type": "bytes32" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "checkSignatures",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "prevModule", "type": "address" },
+      { "internalType": "address", "name": "module", "type": "address" }
+    ],
+    "name": "disableModule",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domainSeparator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "module", "type": "address" }],
+    "name": "enableModule",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" },
+      { "internalType": "uint256", "name": "safeTxGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "baseGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "gasPrice", "type": "uint256" },
+      { "internalType": "address", "name": "gasToken", "type": "address" },
+      { "internalType": "address", "name": "refundReceiver", "type": "address" },
+      { "internalType": "uint256", "name": "_nonce", "type": "uint256" }
+    ],
+    "name": "encodeTransactionData",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" },
+      { "internalType": "uint256", "name": "safeTxGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "baseGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "gasPrice", "type": "uint256" },
+      { "internalType": "address", "name": "gasToken", "type": "address" },
+      { "internalType": "address payable", "name": "refundReceiver", "type": "address" },
+      { "internalType": "bytes", "name": "signatures", "type": "bytes" }
+    ],
+    "name": "execTransaction",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" }
+    ],
+    "name": "execTransactionFromModule",
+    "outputs": [{ "internalType": "bool", "name": "success", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" }
+    ],
+    "name": "execTransactionFromModuleReturnData",
+    "outputs": [
+      { "internalType": "bool", "name": "success", "type": "bool" },
+      { "internalType": "bytes", "name": "returnData", "type": "bytes" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "start", "type": "address" },
+      { "internalType": "uint256", "name": "pageSize", "type": "uint256" }
+    ],
+    "name": "getModulesPaginated",
+    "outputs": [
+      { "internalType": "address[]", "name": "array", "type": "address[]" },
+      { "internalType": "address", "name": "next", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwners",
+    "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "offset", "type": "uint256" },
+      { "internalType": "uint256", "name": "length", "type": "uint256" }
+    ],
+    "name": "getStorageAt",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getThreshold",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" },
+      { "internalType": "uint256", "name": "safeTxGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "baseGas", "type": "uint256" },
+      { "internalType": "uint256", "name": "gasPrice", "type": "uint256" },
+      { "internalType": "address", "name": "gasToken", "type": "address" },
+      { "internalType": "address", "name": "refundReceiver", "type": "address" },
+      { "internalType": "uint256", "name": "_nonce", "type": "uint256" }
+    ],
+    "name": "getTransactionHash",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "module", "type": "address" }],
+    "name": "isModuleEnabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "isOwner",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nonce",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "prevOwner", "type": "address" },
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "uint256", "name": "_threshold", "type": "uint256" }
+    ],
+    "name": "removeOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "uint256", "name": "value", "type": "uint256" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "enum Enum.Operation", "name": "operation", "type": "uint8" }
+    ],
+    "name": "requiredTxGas",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "handler", "type": "address" }],
+    "name": "setFallbackHandler",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "guard", "type": "address" }],
+    "name": "setGuard",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address[]", "name": "_owners", "type": "address[]" },
+      { "internalType": "uint256", "name": "_threshold", "type": "uint256" },
+      { "internalType": "address", "name": "to", "type": "address" },
+      { "internalType": "bytes", "name": "data", "type": "bytes" },
+      { "internalType": "address", "name": "fallbackHandler", "type": "address" },
+      { "internalType": "address", "name": "paymentToken", "type": "address" },
+      { "internalType": "uint256", "name": "payment", "type": "uint256" },
+      { "internalType": "address payable", "name": "paymentReceiver", "type": "address" }
+    ],
+    "name": "setup",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "signedMessages",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "targetContract", "type": "address" },
+      { "internalType": "bytes", "name": "calldataPayload", "type": "bytes" }
+    ],
+    "name": "simulateAndRevert",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "prevOwner", "type": "address" },
+      { "internalType": "address", "name": "oldOwner", "type": "address" },
+      { "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "swapOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/packages/optimistic-governor/manifest/data/arbitrum.json
+++ b/packages/optimistic-governor/manifest/data/arbitrum.json
@@ -11,6 +11,11 @@
       {
         "name": "OptimisticGovernor"
       }
+    ],
+    "SafeDataSources": [
+      {
+        "name": "Safe"
+      }
     ]
   }
   

--- a/packages/optimistic-governor/manifest/data/avalanche.json
+++ b/packages/optimistic-governor/manifest/data/avalanche.json
@@ -11,5 +11,10 @@
     {
       "name": "OptimisticGovernor"
     }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
   ]
 }

--- a/packages/optimistic-governor/manifest/data/gnosis.json
+++ b/packages/optimistic-governor/manifest/data/gnosis.json
@@ -1,16 +1,20 @@
 {
-    "network": "gnosis",
-    "ModuleProxyFactoryDataSources": [
-      {
-        "name": "ModuleProxyFactory",
-        "address": "0x000000000000aDdB49795b0f9bA5BC298cDda236",
-        "startBlock": 27102135
-      }
-    ],
-    "OptimisticGovernorDataSources": [
-      {
-        "name": "OptimisticGovernor"
-      }
-    ]
-  }
-  
+  "network": "gnosis",
+  "ModuleProxyFactoryDataSources": [
+    {
+      "name": "ModuleProxyFactory",
+      "address": "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+      "startBlock": 27102135
+    }
+  ],
+  "OptimisticGovernorDataSources": [
+    {
+      "name": "OptimisticGovernor"
+    }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
+  ]
+}

--- a/packages/optimistic-governor/manifest/data/goerli.json
+++ b/packages/optimistic-governor/manifest/data/goerli.json
@@ -11,5 +11,10 @@
     {
       "name": "OptimisticGovernor"
     }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
   ]
 }

--- a/packages/optimistic-governor/manifest/data/mainnet.json
+++ b/packages/optimistic-governor/manifest/data/mainnet.json
@@ -11,5 +11,10 @@
     {
       "name": "OptimisticGovernor"
     }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
   ]
 }

--- a/packages/optimistic-governor/manifest/data/optimism.json
+++ b/packages/optimistic-governor/manifest/data/optimism.json
@@ -11,5 +11,10 @@
     {
       "name": "OptimisticGovernor"
     }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
   ]
 }

--- a/packages/optimistic-governor/manifest/data/polygon.json
+++ b/packages/optimistic-governor/manifest/data/polygon.json
@@ -11,5 +11,10 @@
     {
       "name": "OptimisticGovernor"
     }
+  ],
+  "SafeDataSources": [
+    {
+      "name": "Safe"
+    }
   ]
 }

--- a/packages/optimistic-governor/manifest/templates/ModuleProxyFactory.template.yaml
+++ b/packages/optimistic-governor/manifest/templates/ModuleProxyFactory.template.yaml
@@ -12,9 +12,15 @@
     file: ./src/index.ts
     entities:
       - Proposal
+      - Safe
+      - OptimisticGovernor
     abis:
       - name: ModuleProxyFactory
         file: ./abis/ModuleProxyFactory.json
+      - name: OptimisticGovernor
+        file: ./abis/OptimisticGovernor.json
+      - name: Safe
+        file: ./abis/Safe.json
     eventHandlers:
       - event: ModuleProxyCreation(indexed address,indexed address)
         handler: handleModuleProxyCreation

--- a/packages/optimistic-governor/manifest/templates/Safe.template.yaml
+++ b/packages/optimistic-governor/manifest/templates/Safe.template.yaml
@@ -2,7 +2,7 @@
   name: {{name}}
   network: {{network}}
   source:
-    abi: OptimisticGovernor
+    abi: Safe
   mapping:
     kind: ethereum/events
     apiVersion: 0.0.7
@@ -20,9 +20,7 @@
       - name: Safe
         file: ./abis/Safe.json
     eventHandlers:
-      - event: TransactionsProposed(indexed address,indexed uint256,indexed bytes32,((address,uint8,uint256,bytes)[],uint256),bytes32,bytes,string,uint256)
-        handler: handleTransactionsProposed
-      - event: ProposalExecuted(indexed bytes32,indexed bytes32)
-        handler: handleProposalExecuted
-      - event:  TargetSet(indexed address,indexed address)
-        handler: handleTargetSet
+      - event: DisabledModule(address)
+        handler: handleSafeDisabledModule
+      - event: EnabledModule(address)
+        handler: handleSafeEnabledModule

--- a/packages/optimistic-governor/manifest/templates/subgraph.template.yaml
+++ b/packages/optimistic-governor/manifest/templates/subgraph.template.yaml
@@ -11,3 +11,6 @@ templates:
 {{#OptimisticGovernorDataSources}}
   {{> OptimisticGovernor.template.yaml}}
 {{/OptimisticGovernorDataSources}}
+{{#SafeDataSources}}
+  {{> Safe.template.yaml}}
+{{/SafeDataSources}}

--- a/packages/optimistic-governor/schema.graphql
+++ b/packages/optimistic-governor/schema.graphql
@@ -17,8 +17,17 @@ type Proposal @entity {
 type OptimisticGovernor @entity {
   "ID is the Optimistic Governor Address"
   id: ID!
-  "The Safe address that deployed this Optimistic Governor"
-  safeAddress: Bytes!
+  "The Safe that deployed this Optimistic Governor"
+  safe: Safe!
   "List of all the proposals made by this governor"
   proposals: [Proposal!]! @derivedFrom(field: "optimisticGovernor")
+}
+
+type Safe @entity {
+  "ID is the safe Address"
+  id: ID!
+  "The Optimistic Governor deployed by this Safe"
+  optimisticGovernor: OptimisticGovernor!
+  "Wether the Optimistic Governor is enabled for this Safe"
+  isOptimisticGovernorEnabled: Boolean
 }

--- a/packages/optimistic-governor/schema.graphql
+++ b/packages/optimistic-governor/schema.graphql
@@ -17,7 +17,7 @@ type Proposal @entity {
 type OptimisticGovernor @entity {
   "ID is the Optimistic Governor Address"
   id: ID!
-  address: Bytes! @id
+  safeAddress: Bytes!
   "List of all the proposals made by this governor"
   proposals: [Proposal!]! @derivedFrom(field: "optimisticGovernor")
 }

--- a/packages/optimistic-governor/schema.graphql
+++ b/packages/optimistic-governor/schema.graphql
@@ -1,7 +1,7 @@
 type Proposal @entity {
   "ID is the Proposal Hash"
   id: ID!
-  ogAddress: Bytes!
+  optimisticGovernor: OptimisticGovernor!
   proposer: Bytes!
   proposalTime: BigInt!
   assertionId: Bytes!
@@ -12,4 +12,12 @@ type Proposal @entity {
   proposalHash: Bytes!
   executed: Boolean!
   executionTransactionHash: String
+}
+
+type OptimisticGovernor @entity {
+  "ID is the Optimistic Governor Address"
+  id: ID!
+  address: Bytes! @id
+  "List of all the proposals made by this governor"
+  proposals: [Proposal!]! @derivedFrom(field: "optimisticGovernor")
 }

--- a/packages/optimistic-governor/schema.graphql
+++ b/packages/optimistic-governor/schema.graphql
@@ -17,6 +17,7 @@ type Proposal @entity {
 type OptimisticGovernor @entity {
   "ID is the Optimistic Governor Address"
   id: ID!
+  "The Safe Address that deployed this Optimistic Governor"
   safeAddress: Bytes!
   "List of all the proposals made by this governor"
   proposals: [Proposal!]! @derivedFrom(field: "optimisticGovernor")

--- a/packages/optimistic-governor/schema.graphql
+++ b/packages/optimistic-governor/schema.graphql
@@ -17,7 +17,7 @@ type Proposal @entity {
 type OptimisticGovernor @entity {
   "ID is the Optimistic Governor Address"
   id: ID!
-  "The Safe Address that deployed this Optimistic Governor"
+  "The Safe address that deployed this Optimistic Governor"
   safeAddress: Bytes!
   "List of all the proposals made by this governor"
   proposals: [Proposal!]! @derivedFrom(field: "optimisticGovernor")

--- a/packages/optimistic-governor/scripts/build-manifest.sh
+++ b/packages/optimistic-governor/scripts/build-manifest.sh
@@ -12,5 +12,6 @@ cat $DATA
 mustache \
   -p manifest/templates/ModuleProxyFactory.template.yaml \
   -p manifest/templates/OptimisticGovernor.template.yaml \
+  -p manifest/templates/Safe.template.yaml \
   $DATA \
   manifest/templates/subgraph.template.yaml > subgraph.yaml

--- a/packages/optimistic-governor/src/index.ts
+++ b/packages/optimistic-governor/src/index.ts
@@ -2,4 +2,7 @@ export {
   handleModuleProxyCreation,
   handleTransactionsProposed,
   handleProposalExecuted,
+  handleTargetSet,
+  handleSafeDisabledModule,
+  handleSafeEnabledModule
 } from "./mappings/optimisticGovernor";

--- a/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
@@ -6,6 +6,7 @@ import { ZERO_ADDRESS } from "../utils/constants";
 import { getOrCreateProposal } from "../utils/helpers";
 
 import { dataSource, log } from "@graphprotocol/graph-ts";
+import { getOrCreateOptimisticGovernor } from "../utils/helpers/optimisticGovernor";
 
 let network = dataSource.network();
 
@@ -41,6 +42,8 @@ export function handleModuleProxyCreation(event: ModuleProxyCreation): void {
       event.params.proxy.toHexString(),
       event.params.masterCopy.toHexString(),
     ]);
+    let optimisticGovernor = getOrCreateOptimisticGovernor(event.params.proxy.toHexString());
+    optimisticGovernor.save();
     OptimisticGovernor.create(event.params.proxy);
   }
 }
@@ -49,7 +52,7 @@ export function handleTransactionsProposed(event: TransactionsProposed): void {
   let proposalId = event.params.assertionId.toHexString();
   let proposal = getOrCreateProposal(proposalId);
 
-  proposal.ogAddress = event.address;
+  proposal.optimisticGovernor = event.address.toHexString();
   proposal.proposer = event.params.proposer;
   proposal.proposalTime = event.params.proposalTime;
   proposal.assertionId = event.params.assertionId;

--- a/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
@@ -5,7 +5,7 @@ import { ZERO_ADDRESS } from "../utils/constants";
 
 import { getOrCreateProposal } from "../utils/helpers";
 
-import { dataSource, log } from "@graphprotocol/graph-ts";
+import { Bytes, dataSource, log } from "@graphprotocol/graph-ts";
 import { getOrCreateOptimisticGovernor } from "../utils/helpers/optimisticGovernor";
 
 let network = dataSource.network();
@@ -43,6 +43,7 @@ export function handleModuleProxyCreation(event: ModuleProxyCreation): void {
       event.params.masterCopy.toHexString(),
     ]);
     let optimisticGovernor = getOrCreateOptimisticGovernor(event.params.proxy.toHexString());
+    optimisticGovernor.safeAddress = event.transaction.to as Bytes;
     optimisticGovernor.save();
     OptimisticGovernor.create(event.params.proxy);
   }

--- a/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
@@ -1,5 +1,5 @@
 import { Bytes } from "@graphprotocol/graph-ts";
-import { OptimisticGovernor, Proposal } from "../../../generated/schema";
+import { OptimisticGovernor, Proposal, Safe } from "../../../generated/schema";
 import { BIGINT_ZERO } from "../constants";
 
 export function getOrCreateOptimisticGovernor(id: string): OptimisticGovernor {
@@ -8,6 +8,14 @@ export function getOrCreateOptimisticGovernor(id: string): OptimisticGovernor {
     og = new OptimisticGovernor(id);
   }
   return og as OptimisticGovernor;
+}
+
+export function getOrCreateSafe(id: string): Safe {
+  let safe = Safe.load(id);
+  if (safe == null) {
+    safe = new Safe(id);
+  }
+  return safe as Safe;
 }
 
 export function getOrCreateProposal(id: string, createIfNotFound: boolean = true): Proposal {

--- a/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
@@ -1,6 +1,15 @@
-import { Bytes } from "@graphprotocol/graph-ts";
-import { Proposal } from "../../../generated/schema";
+import { Bytes, Address } from "@graphprotocol/graph-ts";
+import { OptimisticGovernor, Proposal } from "../../../generated/schema";
 import { BIGINT_ZERO } from "../constants";
+
+export function getOrCreateOptimisticGovernor(id: string): OptimisticGovernor {
+  let og = OptimisticGovernor.load(id);
+  if (og == null) {
+    og = new OptimisticGovernor(id);
+    og.address = Address.fromString(id);
+  }
+  return og as OptimisticGovernor;
+}
 
 export function getOrCreateProposal(id: string, createIfNotFound: boolean = true): Proposal {
   let proposal = Proposal.load(id);

--- a/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/utils/helpers/optimisticGovernor.ts
@@ -1,4 +1,4 @@
-import { Bytes, Address } from "@graphprotocol/graph-ts";
+import { Bytes } from "@graphprotocol/graph-ts";
 import { OptimisticGovernor, Proposal } from "../../../generated/schema";
 import { BIGINT_ZERO } from "../constants";
 
@@ -6,7 +6,6 @@ export function getOrCreateOptimisticGovernor(id: string): OptimisticGovernor {
   let og = OptimisticGovernor.load(id);
   if (og == null) {
     og = new OptimisticGovernor(id);
-    og.address = Address.fromString(id);
   }
   return og as OptimisticGovernor;
 }


### PR DESCRIPTION
Changes proposed in this PR:
- Add Optimistic Governor entity with:
  - ID: OG address
  - safe: safe that deployed the OG
  - proposals list of proposals
- Add Safe entity with:
  - ID: Safe address
  - OptimisticGovernor: the optimistic governor associated with this safe
  - isOptimisticGovernorEnabled: whether this OG associated is enabled in the Safe
  
Use case: check if a safe has OG enabled:
```
{
  safes(where:{id: "0xff07e094fce9ce78128d2c71a1d739597fb17fe3", isOptimisticGovernorEnabled: true}){
    optimisticGovernor {
      id
    }
  }
}
```

This PR is already deployed in goerli and can be tested here: https://thegraph.com/hosted-service/subgraph/md0x/goerli-optimistic-governor you can run the query above