### PR TITLE
fix: add missing og mastercopy for sepolia

### DIFF
--- a/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
+++ b/packages/optimistic-governor/src/mappings/optimisticGovernor.ts
@@ -44,6 +44,9 @@ function getMasterCopy(_network: string): string {
     // Network name conflicts with Core Testnet, below is mainnet, but need to manually set to testnet address if redeploying.
     return "0x596Fd6A5A185c67aBD1c845b39f593fBA9C233aa";
   }
+  if (_network == "sepolia") {
+    return "0x40153DdFAd90C49dbE3F5c9F96f2a5B25ec67461";
+  }
   log.error("No master copy found for network: {}", [_network]);
   return ZERO_ADDRESS;
 }


### PR DESCRIPTION
Forgot to add OptimisticGovernor mastercopy address for Sepolia.
Update has already been deployed on subgraph