### PR TITLE
copy previous commit count

### DIFF
--- a/packages/votingV2/src/mappings/votingV2.ts
+++ b/packages/votingV2/src/mappings/votingV2.ts
@@ -202,6 +202,8 @@ export function handleVoteCommitted(event: VoteCommitted): void {
   let request = getOrCreatePriceRequest(requestId);
   request.latestRound = requestRound.id;
 
+  const _previousNumTokens = vote.numTokens; // defaults to 0 if first commit
+
   vote.voter = voter.id;
   vote.request = requestId;
   vote.identifier = event.params.identifier.toString();
@@ -214,9 +216,7 @@ export function handleVoteCommitted(event: VoteCommitted): void {
   requestRound.time = event.params.time;
   requestRound.roundId = event.params.roundId;
   // if user has voted previously, remove previous token amount, add new
-  requestRound.totalTokensCommitted = requestRound.totalTokensCommitted.minus(toDecimal(vote.numTokens)).plus(toDecimal(voterTokensCommitted));
-
-  // update voter's stake value
+  requestRound.totalTokensCommitted = requestRound.totalTokensCommitted.minus(toDecimal(_previousNumTokens)).plus(toDecimal(voterTokensCommitted));
 
   requestRound.save();
   request.save();


### PR DESCRIPTION
Counting total committed votes is currently broken. the value always remains `0`.
This may be due to s change in this PR https://github.com/UMAprotocol/subgraphs/pull/85