### PR TITLE
set custom liveness and bond at propose time

### DIFF
--- a/packages/managed-oracle-v2/src/mappings/optimisticOracleV2.ts
+++ b/packages/managed-oracle-v2/src/mappings/optimisticOracleV2.ts
@@ -186,6 +186,27 @@ export function handleOptimisticProposePrice(event: ProposePrice): void {
     event.params.ancillaryData
   );
 
+  // Look up custom bond and liveness values that may have been set before the request
+  let customBond = getCustomBond(event.params.requester, event.params.identifier, event.params.ancillaryData);
+  if (customBond !== null) {
+    const bond = customBond.customBond;
+    const currency = customBond.currency;
+    log.debug("custom bond of {} of currency {} was set for request Id: {}", [
+      bond.toString(),
+      currency.toHexString(),
+      requestId,
+    ]);
+    request.bond = bond;
+    request.currency = currency;
+  }
+
+  let customLiveness = getCustomLiveness(event.params.requester, event.params.identifier, event.params.ancillaryData);
+  if (customLiveness !== null) {
+    const liveness = customLiveness.customLiveness;
+    log.debug("custom liveness of {} was set for request Id: {}", [liveness.toString(), requestId]);
+    request.customLiveness = customLiveness.customLiveness;
+  }
+
   request.save();
 }
 

--- a/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
+++ b/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
@@ -1,6 +1,11 @@
 import { createMockedFunction, newMockEvent } from "matchstick-as";
 import { ethereum, BigInt, Address, Bytes } from "@graphprotocol/graph-ts";
-import { CustomBondSet, CustomLivenessSet, RequestPrice } from "../../generated/ManagedOracleV2/ManagedOracleV2";
+import {
+  CustomBondSet,
+  CustomLivenessSet,
+  ProposePrice,
+  RequestPrice,
+} from "../../generated/ManagedOracleV2/ManagedOracleV2";
 
 export const contractAddress = Address.fromString("0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7"); // Default test contract address
 
@@ -120,6 +125,59 @@ export function createRequestPriceEvent(
   );
 
   return requestPriceEvent;
+}
+
+export function createProposePriceEvent(
+  requester: string, // Address,
+  proposer: string, // Address,
+  identifier: string, // Bytes,
+  timestamp: i32, // BigInt,
+  ancillaryData: string, // Bytes,
+  proposedPrice: i32, // BigInt,
+  expirationTimestamp: i32, // BigInt,
+  currency: string // Address
+): ProposePrice {
+  let proposePriceEvent = changetype<ProposePrice>(newMockEvent());
+  proposePriceEvent.address = contractAddress;
+  proposePriceEvent.parameters = new Array();
+
+  // requester
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("requester", ethereum.Value.fromAddress(Address.fromString(requester)))
+  );
+  // proposer
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("proposer", ethereum.Value.fromAddress(Address.fromString(proposer)))
+  );
+  // identifier
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("identifier", ethereum.Value.fromBytes(Bytes.fromHexString(identifier)))
+  );
+  // timestamp
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("timestamp", ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(timestamp)))
+  );
+  // ancillaryData
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("ancillaryData", ethereum.Value.fromBytes(Bytes.fromHexString(ancillaryData)))
+  );
+  // proposedPrice
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("proposedPrice", ethereum.Value.fromSignedBigInt(BigInt.fromI32(proposedPrice)))
+  );
+  // expirationTimestamp
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam(
+      "expirationTimestamp",
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(expirationTimestamp))
+    )
+  );
+  // currency
+  proposePriceEvent.parameters.push(
+    new ethereum.EventParam("currency", ethereum.Value.fromAddress(Address.fromString(currency)))
+  );
+
+  return proposePriceEvent;
 }
 
 // https://github.com/UMAprotocol/protocol/blob/99b96247d27ec8a5ea9dbf3eef1dcd71beb0dc41/packages/core/contracts/optimistic-oracle-v2/interfaces/OptimisticOracleV2Interface.sol#L51


### PR DESCRIPTION
## Motivation
Per the MOOv2 contract, admin may set `customLiveness` and `customBond` after request time and before proposal time. Update the request Price entity at propose time.