### PR TITLE
feat: add resolver tracking for MOOV2 early resolver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ This subgraph indexes events and function calls by the "Managed Optimistic Oracl
   - Goldsky: <https://api.goldsky.com/api/public/project_clus2fndawbcc01w31192938i/subgraphs/amoy-managed-optimistic-oracle-v2/1.1.0/gn>
 - Polygon
   - TheGraph:
-  - Goldsky: <https://api.goldsky.com/api/public/project_clus2fndawbcc01w31192938i/subgraphs/polygon-managed-optimistic-oracle-v2/1.0.4/gn>
+  - Goldsky: <https://api.goldsky.com/api/public/project_clus2fndawbcc01w31192938i/subgraphs/polygon-managed-optimistic-oracle-v2/1.0.5/gn>
 
 ## Financial Contract Events
 

--- a/packages/managed-oracle-v2/abis/ManagedOracleV2.json
+++ b/packages/managed-oracle-v2/abis/ManagedOracleV2.json
@@ -1,406 +1,2676 @@
 [
   {
-    "inputs": [
-      { "internalType": "uint256", "name": "_liveness", "type": "uint256" },
-      { "internalType": "address", "name": "_finderAddress", "type": "address" },
-      { "internalType": "address", "name": "_timerAddress", "type": "address" }
-    ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "disputer", "type": "address" },
-      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": false, "internalType": "int256", "name": "proposedPrice", "type": "int256" }
-    ],
-    "name": "DisputePrice",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
-      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": false, "internalType": "int256", "name": "proposedPrice", "type": "int256" },
-      { "indexed": false, "internalType": "uint256", "name": "expirationTimestamp", "type": "uint256" },
-      { "indexed": false, "internalType": "address", "name": "currency", "type": "address" }
-    ],
-    "name": "ProposePrice",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": false, "internalType": "address", "name": "currency", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "reward", "type": "uint256" },
-      { "indexed": false, "internalType": "uint256", "name": "finalFee", "type": "uint256" }
-    ],
-    "name": "RequestPrice",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
-      { "indexed": true, "internalType": "address", "name": "disputer", "type": "address" },
-      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": false, "internalType": "int256", "name": "price", "type": "int256" },
-      { "indexed": false, "internalType": "uint256", "name": "payout", "type": "uint256" }
-    ],
-    "name": "Settle",
-    "type": "event"
-  },
-  {
+    "type": "constructor",
     "inputs": [],
-    "name": "OO_ANCILLARY_DATA_LIMIT",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "nonpayable"
   },
   {
+    "type": "function",
+    "name": "CONFIG_ADMIN_ROLE",
     "inputs": [],
-    "name": "TOO_EARLY_RESPONSE",
-    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ancillaryBytesLimit",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "defaultLiveness",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "disputePrice",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "disputer", "type": "address" },
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "disputePriceFor",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "finder",
-    "outputs": [{ "internalType": "contract FinderInterface", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "getCurrentTime",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "getRequest",
     "outputs": [
       {
-        "components": [
-          { "internalType": "address", "name": "proposer", "type": "address" },
-          { "internalType": "address", "name": "disputer", "type": "address" },
-          { "internalType": "contract IERC20", "name": "currency", "type": "address" },
-          { "internalType": "bool", "name": "settled", "type": "bool" },
-          {
-            "components": [
-              { "internalType": "bool", "name": "eventBased", "type": "bool" },
-              { "internalType": "bool", "name": "refundOnDispute", "type": "bool" },
-              { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
-              { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
-              { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" },
-              { "internalType": "uint256", "name": "bond", "type": "uint256" },
-              { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
-            ],
-            "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
-            "name": "requestSettings",
-            "type": "tuple"
-          },
-          { "internalType": "int256", "name": "proposedPrice", "type": "int256" },
-          { "internalType": "int256", "name": "resolvedPrice", "type": "int256" },
-          { "internalType": "uint256", "name": "expirationTime", "type": "uint256" },
-          { "internalType": "uint256", "name": "reward", "type": "uint256" },
-          { "internalType": "uint256", "name": "finalFee", "type": "uint256" }
-        ],
-        "internalType": "struct OptimisticOracleV2Interface.Request",
         "name": "",
-        "type": "tuple"
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
+    "stateMutability": "view"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "getState",
-    "outputs": [{ "internalType": "enum OptimisticOracleV2Interface.State", "name": "", "type": "uint8" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "hasPrice",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "int256", "name": "proposedPrice", "type": "int256" }
-    ],
-    "name": "proposePrice",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "proposer", "type": "address" },
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "int256", "name": "proposedPrice", "type": "int256" }
-    ],
-    "name": "proposePriceFor",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "contract IERC20", "name": "currency", "type": "address" },
-      { "internalType": "uint256", "name": "reward", "type": "uint256" }
-    ],
-    "name": "requestPrice",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "requests",
-    "outputs": [
-      { "internalType": "address", "name": "proposer", "type": "address" },
-      { "internalType": "address", "name": "disputer", "type": "address" },
-      { "internalType": "contract IERC20", "name": "currency", "type": "address" },
-      { "internalType": "bool", "name": "settled", "type": "bool" },
-      {
-        "components": [
-          { "internalType": "bool", "name": "eventBased", "type": "bool" },
-          { "internalType": "bool", "name": "refundOnDispute", "type": "bool" },
-          { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
-          { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
-          { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" },
-          { "internalType": "uint256", "name": "bond", "type": "uint256" },
-          { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
-        ],
-        "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
-        "name": "requestSettings",
-        "type": "tuple"
-      },
-      { "internalType": "int256", "name": "proposedPrice", "type": "int256" },
-      { "internalType": "int256", "name": "resolvedPrice", "type": "int256" },
-      { "internalType": "uint256", "name": "expirationTime", "type": "uint256" },
-      { "internalType": "uint256", "name": "reward", "type": "uint256" },
-      { "internalType": "uint256", "name": "finalFee", "type": "uint256" }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "uint256", "name": "bond", "type": "uint256" }
-    ],
-    "name": "setBond",
-    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
-      { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
-      { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" }
-    ],
-    "name": "setCallbacks",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "uint256", "name": "time", "type": "uint256" }],
-    "name": "setCurrentTime",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
-    ],
-    "name": "setCustomLiveness",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "setEventBased",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "setRefundOnDispute",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "requester", "type": "address" },
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "settle",
-    "outputs": [{ "internalType": "uint256", "name": "payout", "type": "uint256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
-    ],
-    "name": "settleAndGetPrice",
-    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "internalType": "address", "name": "requester", "type": "address" }
-    ],
-    "name": "stampAncillaryData",
-    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
+    "type": "function",
+    "name": "DEFAULT_ADMIN_ROLE",
     "inputs": [],
-    "name": "timerAddress",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "bytes32", "name": "managedRequestId", "type": "bytes32" },
-      { "indexed": false, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": true, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": true, "internalType": "contract IERC20", "name": "currency", "type": "address" },
-      { "indexed": false, "internalType": "uint256", "name": "bond", "type": "uint256" }
+    "type": "function",
+    "name": "LOWEST_MINIMUM_DISPUTE_WINDOW",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
     ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "OO_ANCILLARY_DATA_LIMIT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "REQUEST_MANAGER_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RESOLVER_ADMIN_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "RESOLVER_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "TOO_EARLY_RESPONSE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_ADMIN_ROLE",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "acceptDefaultAdminTransfer",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addRequestManager",
+    "inputs": [
+      {
+        "name": "requestManager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addResolver",
+    "inputs": [
+      {
+        "name": "resolver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "allowedBondRanges",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "minimumBond",
+        "type": "uint128",
+        "internalType": "uint128"
+      },
+      {
+        "name": "maximumBond",
+        "type": "uint128",
+        "internalType": "uint128"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ancillaryBytesLimit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "beginDefaultAdminTransfer",
+    "inputs": [
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelDefaultAdminTransfer",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "changeDefaultAdminDelay",
+    "inputs": [
+      {
+        "name": "newDelay",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimDeferredPayout",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "repaymentAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "customBonds",
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "isSet",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "customLivenessValues",
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "liveness",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "isSet",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "customProposerWhitelists",
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AddressWhitelistInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "defaultAdmin",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "defaultAdminDelay",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "defaultAdminDelayIncreaseWait",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "defaultLiveness",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "defaultProposerWhitelist",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AddressWhitelistInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deferredPayouts",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "deferredRecipient",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "disputePrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "disputePriceFor",
+    "inputs": [
+      {
+        "name": "disputer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finder",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract FinderInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCurrentTime",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getCustomProposerWhitelist",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AddressWhitelistInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getManagedRequestId",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getProposerWhitelistWithEnabledStatus",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "allowedProposers",
+        "type": "address[]",
+        "internalType": "address[]"
+      },
+      {
+        "name": "isEnabled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRequest",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "tuple",
+        "internalType": "struct OptimisticOracleV2Interface.Request",
+        "components": [
+          {
+            "name": "proposer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "disputer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "contract IERC20"
+          },
+          {
+            "name": "settled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "requestSettings",
+            "type": "tuple",
+            "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
+            "components": [
+              {
+                "name": "eventBased",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "refundOnDispute",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "callbackOnPriceProposed",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "callbackOnPriceDisputed",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "callbackOnPriceSettled",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "bond",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "customLiveness",
+                "type": "uint256",
+                "internalType": "uint256"
+              }
+            ]
+          },
+          {
+            "name": "proposedPrice",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "resolvedPrice",
+            "type": "int256",
+            "internalType": "int256"
+          },
+          {
+            "name": "expirationTime",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "reward",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "finalFee",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "proposalTime",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRoleAdmin",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getState",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum OptimisticOracleV2Interface.State"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "grantRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "hasPrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "hasRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_defaultLiveness",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_finderAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_defaultProposerWhitelist",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_requesterWhitelist",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_allowedBondRanges",
+        "type": "tuple[]",
+        "internalType": "struct ManagedOptimisticOracleV2.CurrencyBondRange[]",
+        "components": [
+          {
+            "name": "currency",
+            "type": "address",
+            "internalType": "contract IERC20"
+          },
+          {
+            "name": "range",
+            "type": "tuple",
+            "internalType": "struct ManagedOptimisticOracleV2.BondRange",
+            "components": [
+              {
+                "name": "minimumBond",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "maximumBond",
+                "type": "uint128",
+                "internalType": "uint128"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "configAdmin",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "upgradeAdmin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "_liveness",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "_finderAddress",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "upgradeAdmin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "initializeV2",
+    "inputs": [
+      {
+        "name": "_minimumDisputeWindow",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "resolverAdmin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "minimumDisputeWindow",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "multicall",
+    "inputs": [
+      {
+        "name": "data",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "results",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "owner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingDefaultAdmin",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "schedule",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pendingDefaultAdminDelay",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "newDelay",
+        "type": "uint48",
+        "internalType": "uint48"
+      },
+      {
+        "name": "schedule",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "proposePrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "proposedPrice",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "proposePriceFor",
+    "inputs": [
+      {
+        "name": "proposer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "proposedPrice",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "proxiableUUID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeRequestManager",
+    "inputs": [
+      {
+        "name": "requestManager",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "removeResolver",
+    "inputs": [
+      {
+        "name": "resolver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "renounceRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestManagerSetBond",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "bond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestManagerSetCustomLiveness",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "customLiveness",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestManagerSetProposerWhitelist",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "whitelist",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestPrice",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "reward",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requesterWhitelist",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract AddressWhitelistInterface"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "requests",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proposer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "disputer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "settled",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "requestSettings",
+        "type": "tuple",
+        "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
+        "components": [
+          {
+            "name": "eventBased",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "refundOnDispute",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "callbackOnPriceProposed",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "callbackOnPriceDisputed",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "callbackOnPriceSettled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "bond",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "customLiveness",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "proposedPrice",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "resolvedPrice",
+        "type": "int256",
+        "internalType": "int256"
+      },
+      {
+        "name": "expirationTime",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "reward",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "finalFee",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "proposalTime",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "revokeRole",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "rollbackDefaultAdminDelay",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAllowedBondRange",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "newRange",
+        "type": "tuple",
+        "internalType": "struct ManagedOptimisticOracleV2.BondRange",
+        "components": [
+          {
+            "name": "minimumBond",
+            "type": "uint128",
+            "internalType": "uint128"
+          },
+          {
+            "name": "maximumBond",
+            "type": "uint128",
+            "internalType": "uint128"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setBond",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "bond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalBond",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setCallbacks",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "callbackOnPriceProposed",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "callbackOnPriceDisputed",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "callbackOnPriceSettled",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setCustomLiveness",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "customLiveness",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDefaultProposerWhitelist",
+    "inputs": [
+      {
+        "name": "whitelist",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setEventBased",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMinimumDisputeWindow",
+    "inputs": [
+      {
+        "name": "_minimumDisputeWindow",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRefundOnDispute",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setRequesterWhitelist",
+    "inputs": [
+      {
+        "name": "whitelist",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payout",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleAndGetPrice",
+    "inputs": [
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "int256",
+        "internalType": "int256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "stampAncillaryData",
+    "inputs": [
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "upgradeToAndCall",
+    "inputs": [
+      {
+        "name": "newImplementation",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "AllowedBondRangeUpdated",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "newMinimumBond",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "newMaximumBond",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ClaimedDeferredPayout",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "deferredRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "repaymentAddress",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "CustomBondSet",
-    "type": "event"
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": true,
+        "internalType": "contract IERC20"
+      },
+      {
+        "name": "bond",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
   },
   {
-    "anonymous": false,
-    "inputs": [
-      { "indexed": true, "internalType": "bytes32", "name": "managedRequestId", "type": "bytes32" },
-      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
-      { "indexed": true, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
-      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
-      { "indexed": false, "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
-    ],
+    "type": "event",
     "name": "CustomLivenessSet",
-    "type": "event"
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "customLiveness",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "CustomProposerWhitelistSet",
+    "inputs": [
+      {
+        "name": "managedRequestId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "newWhitelist",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultAdminDelayChangeCanceled",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultAdminDelayChangeScheduled",
+    "inputs": [
+      {
+        "name": "newDelay",
+        "type": "uint48",
+        "indexed": false,
+        "internalType": "uint48"
+      },
+      {
+        "name": "effectSchedule",
+        "type": "uint48",
+        "indexed": false,
+        "internalType": "uint48"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultAdminTransferCanceled",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultAdminTransferScheduled",
+    "inputs": [
+      {
+        "name": "newAdmin",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "acceptSchedule",
+        "type": "uint48",
+        "indexed": false,
+        "internalType": "uint48"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DefaultProposerWhitelistUpdated",
+    "inputs": [
+      {
+        "name": "newWhitelist",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DisputePrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "proposer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "disputer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "proposedPrice",
+        "type": "int256",
+        "indexed": false,
+        "internalType": "int256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinimumDisputeWindowUpdated",
+    "inputs": [
+      {
+        "name": "newMinimumDisputeWindow",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayoutDeferred",
+    "inputs": [
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "deferredRecipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProposePrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "proposer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "proposedPrice",
+        "type": "int256",
+        "indexed": false,
+        "internalType": "int256"
+      },
+      {
+        "name": "expirationTimestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequestPrice",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "currency",
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      },
+      {
+        "name": "reward",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "finalFee",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RequesterWhitelistUpdated",
+    "inputs": [
+      {
+        "name": "newWhitelist",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleAdminChanged",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "previousAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newAdminRole",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleGranted",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleRevoked",
+    "inputs": [
+      {
+        "name": "role",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Settle",
+    "inputs": [
+      {
+        "name": "requester",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "proposer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "disputer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "identifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "timestamp",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "ancillaryData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "price",
+        "type": "int256",
+        "indexed": false,
+        "internalType": "int256"
+      },
+      {
+        "name": "payout",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AccessControlBadConfirmation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AccessControlEnforcedDefaultAdminDelay",
+    "inputs": [
+      {
+        "name": "schedule",
+        "type": "uint48",
+        "internalType": "uint48"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AccessControlEnforcedDefaultAdminRules",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AccessControlInvalidDefaultAdmin",
+    "inputs": [
+      {
+        "name": "defaultAdmin",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AccessControlUnauthorizedAccount",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "neededRole",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AddressEmptyCode",
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "AncillaryDataTooLong",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BondBelowMinimumBond",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "BondExceedsMaximumBond",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "CannotProposeTooEarly",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DisputerAddressCannotBeZero",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ERC1967InvalidImplementation",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC1967NonPayable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LivenessCannotBeZero",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LivenessTooLarge",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LivenessTooLow",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumBondAboveMaximumBond",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumDisputeWindowTooLarge",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MinimumDisputeWindowTooSmall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoDeferredPayoutToClaim",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ProposerAddressCannotBeZero",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ProposerNotWhitelisted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RepaymentAddressCannotBeZero",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequestNotSettleable",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequestNotSettled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequestStateNotInvalid",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequestStateNotProposed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequestStateNotRequested",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RequesterNotWhitelisted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SafeCastOverflowedUintDowncast",
+    "inputs": [
+      {
+        "name": "bits",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "SafeERC20FailedOperation",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "SenderNotWhitelisted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TimestampInFuture",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnauthorizedCallContext",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UUPSUnsupportedProxiableUUID",
+    "inputs": [
+      {
+        "name": "slot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnsupportedCurrency",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnsupportedIdentifier",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnsupportedWhitelistInterface",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroBondNotAllowed",
+    "inputs": []
   }
 ]

--- a/packages/managed-oracle-v2/abis/ManagedOracleV2Legacy.json
+++ b/packages/managed-oracle-v2/abis/ManagedOracleV2Legacy.json
@@ -1,0 +1,406 @@
+[
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_liveness", "type": "uint256" },
+      { "internalType": "address", "name": "_finderAddress", "type": "address" },
+      { "internalType": "address", "name": "_timerAddress", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "disputer", "type": "address" },
+      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "int256", "name": "proposedPrice", "type": "int256" }
+    ],
+    "name": "DisputePrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
+      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "int256", "name": "proposedPrice", "type": "int256" },
+      { "indexed": false, "internalType": "uint256", "name": "expirationTimestamp", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "currency", "type": "address" }
+    ],
+    "name": "ProposePrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "address", "name": "currency", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "finalFee", "type": "uint256" }
+    ],
+    "name": "RequestPrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "proposer", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "disputer", "type": "address" },
+      { "indexed": false, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "int256", "name": "price", "type": "int256" },
+      { "indexed": false, "internalType": "uint256", "name": "payout", "type": "uint256" }
+    ],
+    "name": "Settle",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "OO_ANCILLARY_DATA_LIMIT",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "TOO_EARLY_RESPONSE",
+    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ancillaryBytesLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "defaultLiveness",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "disputePrice",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "disputer", "type": "address" },
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "disputePriceFor",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "finder",
+    "outputs": [{ "internalType": "contract FinderInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "getRequest",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "proposer", "type": "address" },
+          { "internalType": "address", "name": "disputer", "type": "address" },
+          { "internalType": "contract IERC20", "name": "currency", "type": "address" },
+          { "internalType": "bool", "name": "settled", "type": "bool" },
+          {
+            "components": [
+              { "internalType": "bool", "name": "eventBased", "type": "bool" },
+              { "internalType": "bool", "name": "refundOnDispute", "type": "bool" },
+              { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
+              { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
+              { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" },
+              { "internalType": "uint256", "name": "bond", "type": "uint256" },
+              { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
+            ],
+            "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
+            "name": "requestSettings",
+            "type": "tuple"
+          },
+          { "internalType": "int256", "name": "proposedPrice", "type": "int256" },
+          { "internalType": "int256", "name": "resolvedPrice", "type": "int256" },
+          { "internalType": "uint256", "name": "expirationTime", "type": "uint256" },
+          { "internalType": "uint256", "name": "reward", "type": "uint256" },
+          { "internalType": "uint256", "name": "finalFee", "type": "uint256" }
+        ],
+        "internalType": "struct OptimisticOracleV2Interface.Request",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "getState",
+    "outputs": [{ "internalType": "enum OptimisticOracleV2Interface.State", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "hasPrice",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "int256", "name": "proposedPrice", "type": "int256" }
+    ],
+    "name": "proposePrice",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "proposer", "type": "address" },
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "int256", "name": "proposedPrice", "type": "int256" }
+    ],
+    "name": "proposePriceFor",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "contract IERC20", "name": "currency", "type": "address" },
+      { "internalType": "uint256", "name": "reward", "type": "uint256" }
+    ],
+    "name": "requestPrice",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "requests",
+    "outputs": [
+      { "internalType": "address", "name": "proposer", "type": "address" },
+      { "internalType": "address", "name": "disputer", "type": "address" },
+      { "internalType": "contract IERC20", "name": "currency", "type": "address" },
+      { "internalType": "bool", "name": "settled", "type": "bool" },
+      {
+        "components": [
+          { "internalType": "bool", "name": "eventBased", "type": "bool" },
+          { "internalType": "bool", "name": "refundOnDispute", "type": "bool" },
+          { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
+          { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
+          { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" },
+          { "internalType": "uint256", "name": "bond", "type": "uint256" },
+          { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
+        ],
+        "internalType": "struct OptimisticOracleV2Interface.RequestSettings",
+        "name": "requestSettings",
+        "type": "tuple"
+      },
+      { "internalType": "int256", "name": "proposedPrice", "type": "int256" },
+      { "internalType": "int256", "name": "resolvedPrice", "type": "int256" },
+      { "internalType": "uint256", "name": "expirationTime", "type": "uint256" },
+      { "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "internalType": "uint256", "name": "finalFee", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "uint256", "name": "bond", "type": "uint256" }
+    ],
+    "name": "setBond",
+    "outputs": [{ "internalType": "uint256", "name": "totalBond", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "bool", "name": "callbackOnPriceProposed", "type": "bool" },
+      { "internalType": "bool", "name": "callbackOnPriceDisputed", "type": "bool" },
+      { "internalType": "bool", "name": "callbackOnPriceSettled", "type": "bool" }
+    ],
+    "name": "setCallbacks",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "time", "type": "uint256" }],
+    "name": "setCurrentTime",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
+    ],
+    "name": "setCustomLiveness",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "setEventBased",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "setRefundOnDispute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "requester", "type": "address" },
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "settle",
+    "outputs": [{ "internalType": "uint256", "name": "payout", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "internalType": "uint256", "name": "timestamp", "type": "uint256" },
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" }
+    ],
+    "name": "settleAndGetPrice",
+    "outputs": [{ "internalType": "int256", "name": "", "type": "int256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "internalType": "address", "name": "requester", "type": "address" }
+    ],
+    "name": "stampAncillaryData",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "timerAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "managedRequestId", "type": "bytes32" },
+      { "indexed": false, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": true, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": true, "internalType": "contract IERC20", "name": "currency", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "bond", "type": "uint256" }
+    ],
+    "name": "CustomBondSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "bytes32", "name": "managedRequestId", "type": "bytes32" },
+      { "indexed": true, "internalType": "address", "name": "requester", "type": "address" },
+      { "indexed": true, "internalType": "bytes32", "name": "identifier", "type": "bytes32" },
+      { "indexed": false, "internalType": "bytes", "name": "ancillaryData", "type": "bytes" },
+      { "indexed": false, "internalType": "uint256", "name": "customLiveness", "type": "uint256" }
+    ],
+    "name": "CustomLivenessSet",
+    "type": "event"
+  }
+]

--- a/packages/managed-oracle-v2/manifest/templates/ManagedOracleV2.template.yaml
+++ b/packages/managed-oracle-v2/manifest/templates/ManagedOracleV2.template.yaml
@@ -20,6 +20,8 @@
     abis:
       - name: ManagedOracleV2
         file: ./abis/ManagedOracleV2.json
+      - name: ManagedOracleV2Legacy
+        file: ./abis/ManagedOracleV2Legacy.json
     eventHandlers:
       - event: RequestPrice(indexed address,bytes32,uint256,bytes,address,uint256,uint256)
         handler: handleOptimisticRequestPrice

--- a/packages/managed-oracle-v2/manifest/templates/ManagedOracleV2.template.yaml
+++ b/packages/managed-oracle-v2/manifest/templates/ManagedOracleV2.template.yaml
@@ -15,6 +15,8 @@
       - PriceIdentifier
       - CustomLiveness
       - CustomBond
+      - Resolver
+      - ResolverHistory
     abis:
       - name: ManagedOracleV2
         file: ./abis/ManagedOracleV2.json
@@ -31,6 +33,10 @@
         handler: handleCustomLivenessSet
       - event: CustomBondSet(indexed bytes32,address,indexed bytes32,bytes,indexed address,uint256)
         handler: handleCustomBondSet
+      - event: RoleGranted(indexed bytes32,indexed address,indexed address)
+        handler: handleRoleGranted
+      - event: RoleRevoked(indexed bytes32,indexed address,indexed address)
+        handler: handleRoleRevoked
     callHandlers:
       - function: setCustomLiveness(bytes32,uint256,bytes,uint256)
         handler: handleSetCustomLiveness

--- a/packages/managed-oracle-v2/schema.graphql
+++ b/packages/managed-oracle-v2/schema.graphql
@@ -110,3 +110,35 @@ type CustomLiveness @entity {
 
   customLiveness: BigInt!
 }
+
+type Resolver @entity {
+  "ID is the resolver address"
+  id: ID!
+
+  address: Bytes!
+
+  isActive: Boolean!
+
+  addedAt: BigInt
+
+  addedTx: Bytes
+
+  removedAt: BigInt
+
+  removedTx: Bytes
+}
+
+type ResolverHistory @entity {
+  "ID is tx hash + log index"
+  id: ID!
+
+  resolver: Bytes!
+
+  action: String!
+
+  timestamp: BigInt!
+
+  blockNumber: BigInt!
+
+  transactionHash: Bytes!
+}

--- a/packages/managed-oracle-v2/src/index.ts
+++ b/packages/managed-oracle-v2/src/index.ts
@@ -7,4 +7,4 @@ export {
   handleSetCustomLiveness,
   handleSetEventBased,
 } from "./mappings/optimisticOracleV2";
-export { handleCustomBondSet, handleCustomLivenessSet } from "./mappings/managedOracleV2";
+export { handleCustomBondSet, handleCustomLivenessSet, handleRoleGranted, handleRoleRevoked } from "./mappings/managedOracleV2";

--- a/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
+++ b/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
@@ -5,7 +5,12 @@ import {
   CustomLivenessSet,
   ProposePrice,
   RequestPrice,
+  RoleGranted,
+  RoleRevoked,
 } from "../../generated/ManagedOracleV2/ManagedOracleV2";
+
+// RESOLVER_ROLE = keccak256("RESOLVER_ROLE")
+export const RESOLVER_ROLE = Bytes.fromHexString("0x92a19c77d2ea87c7f81d50c74403cb2f401780f3ad919571121efe2bdb427eb1");
 
 export const contractAddress = Address.fromString("0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7"); // Default test contract address
 
@@ -206,4 +211,54 @@ export function mockGetState(
       ethereum.Value.fromBytes(Bytes.fromHexString(ancillaryData)),
     ])
     .returns([ethereum.Value.fromI32(expectedState)]);
+}
+
+export function createRoleGrantedEvent(
+  role: Bytes,
+  account: string,
+  sender: string
+): RoleGranted {
+  let roleGrantedEvent = changetype<RoleGranted>(newMockEvent());
+  roleGrantedEvent.address = contractAddress;
+  roleGrantedEvent.parameters = new Array();
+
+  // role
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromFixedBytes(role))
+  );
+  // account
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(Address.fromString(account)))
+  );
+  // sender
+  roleGrantedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(Address.fromString(sender)))
+  );
+
+  return roleGrantedEvent;
+}
+
+export function createRoleRevokedEvent(
+  role: Bytes,
+  account: string,
+  sender: string
+): RoleRevoked {
+  let roleRevokedEvent = changetype<RoleRevoked>(newMockEvent());
+  roleRevokedEvent.address = contractAddress;
+  roleRevokedEvent.parameters = new Array();
+
+  // role
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("role", ethereum.Value.fromFixedBytes(role))
+  );
+  // account
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("account", ethereum.Value.fromAddress(Address.fromString(account)))
+  );
+  // sender
+  roleRevokedEvent.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(Address.fromString(sender)))
+  );
+
+  return roleRevokedEvent;
 }

--- a/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
+++ b/packages/managed-oracle-v2/tests/managed-oracle-v2/utils.ts
@@ -238,6 +238,130 @@ export function createRoleGrantedEvent(
   return roleGrantedEvent;
 }
 
+// Function signatures used by the generated ABI bindings
+const GET_REQUEST_NEW_SIG = "getRequest(address,bytes32,uint256,bytes):((address,address,address,bool,(bool,bool,bool,bool,bool,uint256,uint256),int256,int256,uint256,uint256,uint256,uint256))";
+const GET_REQUEST_LEGACY_SIG = "getRequest(address,bytes32,uint256,bytes):((address,address,address,bool,(bool,bool,bool,bool,bool,uint256,uint256),int256,int256,uint256,uint256,uint256))";
+
+function getRequestArgs(
+  requester: string,
+  identifier: string,
+  timestamp: i32,
+  ancillaryData: string
+): ethereum.Value[] {
+  return [
+    ethereum.Value.fromAddress(Address.fromString(requester)),
+    ethereum.Value.fromFixedBytes(Bytes.fromHexString(identifier)),
+    ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(timestamp)),
+    ethereum.Value.fromBytes(Bytes.fromHexString(ancillaryData)),
+  ];
+}
+
+function buildRequestSettingsTuple(
+  bond: i32,
+  eventBased: bool,
+  customLiveness: i32
+): ethereum.Tuple {
+  let settings = new ethereum.Tuple();
+  settings.push(ethereum.Value.fromBoolean(eventBased));
+  settings.push(ethereum.Value.fromBoolean(false)); // refundOnDispute
+  settings.push(ethereum.Value.fromBoolean(false)); // callbackOnPriceProposed
+  settings.push(ethereum.Value.fromBoolean(false)); // callbackOnPriceDisputed
+  settings.push(ethereum.Value.fromBoolean(false)); // callbackOnPriceSettled
+  settings.push(ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(bond)));
+  settings.push(ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(customLiveness)));
+  return settings;
+}
+
+/**
+ * Mocks getRequest with the new ABI (includes proposalTime field).
+ * Used when simulating a contract deployed from audit-permissioned-resolver.
+ */
+export function mockGetRequestNewABI(
+  requester: string,
+  identifier: string,
+  timestamp: i32,
+  ancillaryData: string,
+  bond: i32,
+  eventBased: bool,
+  customLiveness: i32
+): void {
+  let requestTuple = new ethereum.Tuple();
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // proposer
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // disputer
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // currency
+  requestTuple.push(ethereum.Value.fromBoolean(false)); // settled
+  requestTuple.push(ethereum.Value.fromTuple(buildRequestSettingsTuple(bond, eventBased, customLiveness)));
+  requestTuple.push(ethereum.Value.fromSignedBigInt(BigInt.zero())); // proposedPrice
+  requestTuple.push(ethereum.Value.fromSignedBigInt(BigInt.zero())); // resolvedPrice
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // expirationTime
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // reward
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // finalFee
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // proposalTime
+
+  createMockedFunction(contractAddress, "getRequest", GET_REQUEST_NEW_SIG)
+    .withArgs(getRequestArgs(requester, identifier, timestamp, ancillaryData))
+    .returns([ethereum.Value.fromTuple(requestTuple)]);
+}
+
+/**
+ * Mocks getRequest with the new ABI to revert.
+ * Simulates calling a contract that doesn't have the proposalTime field.
+ */
+export function mockGetRequestNewABIReverts(
+  requester: string,
+  identifier: string,
+  timestamp: i32,
+  ancillaryData: string
+): void {
+  createMockedFunction(contractAddress, "getRequest", GET_REQUEST_NEW_SIG)
+    .withArgs(getRequestArgs(requester, identifier, timestamp, ancillaryData))
+    .reverts();
+}
+
+/**
+ * Mocks getRequest with the legacy ABI (no proposalTime field).
+ * Used when simulating a pre-upgrade or opt-in-early-resolution contract.
+ */
+export function mockGetRequestLegacyABI(
+  requester: string,
+  identifier: string,
+  timestamp: i32,
+  ancillaryData: string,
+  bond: i32,
+  eventBased: bool,
+  customLiveness: i32
+): void {
+  let requestTuple = new ethereum.Tuple();
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // proposer
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // disputer
+  requestTuple.push(ethereum.Value.fromAddress(Address.zero())); // currency
+  requestTuple.push(ethereum.Value.fromBoolean(false)); // settled
+  requestTuple.push(ethereum.Value.fromTuple(buildRequestSettingsTuple(bond, eventBased, customLiveness)));
+  requestTuple.push(ethereum.Value.fromSignedBigInt(BigInt.zero())); // proposedPrice
+  requestTuple.push(ethereum.Value.fromSignedBigInt(BigInt.zero())); // resolvedPrice
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // expirationTime
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // reward
+  requestTuple.push(ethereum.Value.fromUnsignedBigInt(BigInt.zero())); // finalFee
+
+  createMockedFunction(contractAddress, "getRequest", GET_REQUEST_LEGACY_SIG)
+    .withArgs(getRequestArgs(requester, identifier, timestamp, ancillaryData))
+    .returns([ethereum.Value.fromTuple(requestTuple)]);
+}
+
+/**
+ * Mocks getRequest with the legacy ABI to revert.
+ */
+export function mockGetRequestLegacyABIReverts(
+  requester: string,
+  identifier: string,
+  timestamp: i32,
+  ancillaryData: string
+): void {
+  createMockedFunction(contractAddress, "getRequest", GET_REQUEST_LEGACY_SIG)
+    .withArgs(getRequestArgs(requester, identifier, timestamp, ancillaryData))
+    .reverts();
+}
+
 export function createRoleRevokedEvent(
   role: Bytes,
   account: string,


### PR DESCRIPTION
- Update ABI with new contract interface (adds `proposalTime` to `Request` struct)
- Add `Resolver` and `ResolverHistory` entities
- Add handlers for `RoleGranted`/`RoleRevoked` events (RESOLVER_ROLE only)
- Add legacy ABI fallback for L2 `getRequest` calls — tries new ABI first, falls back to pre-upgrade ABI if it reverts (handles mixed-version deployments)
- Move network detection inside handler to avoid module-level side effects
- Add tests for resolver tracking and dual-ABI fallback

State handling unchanged — `getState()` already calls on-chain, so past-liveness requests will return `Proposed` instead of `Expired` after the contract upgrade.